### PR TITLE
Typo in installation instructions.

### DIFF
--- a/docs/source/main.rst
+++ b/docs/source/main.rst
@@ -38,7 +38,7 @@ For most users, the latest stable version will be most appropriate.  To
 install, use `pip`_ or `easy_install`_ to automatically download the code from
 the `Python Package Index`_::
 
-    pip pybedtools
+    pip install pybedtools
 
 or::
 


### PR DESCRIPTION
Just noticed a typo in the documentation.
