### PR TITLE
seek() and rewind() added to IntervalFile

### DIFF
--- a/pybedtools/cbedtools.pxd
+++ b/pybedtools/cbedtools.pxd
@@ -66,6 +66,8 @@ cdef extern from "bedFile.h":
     cdef cppclass BedFile:
         BedFile(string)
         void Open()
+        void Rewind()
+        void Seek(unsigned long offset)
         void Close()
         BED  GetNextBed()
         void loadBedFileIntoMap()

--- a/pybedtools/cbedtools.pyx
+++ b/pybedtools/cbedtools.pyx
@@ -556,6 +556,25 @@ cdef class IntervalFile:
         self.intervalFile_ptr.loadBedFileIntoMap()
         self._loaded = 1
 
+    def rewind(self):
+        """
+        Jump to the beginning of the file.
+        """
+        if not self._open:
+            self.intervalFile_ptr.Open()
+            self._open = 1
+        self.intervalFile_ptr.Rewind()
+
+    def seek(self, offset):
+        """
+        Jump to a specific byte offset in the file
+        """
+        if not self._open:
+            self.intervalFile_ptr.Open()
+            self._open = 1
+        self.intervalFile_ptr.Seek(offset)
+
+
     def all_hits(self, Interval interval, bool same_strand=False, float overlap=0.0):
         """
         :Signature: `IntervalFile.all_hits(interval, same_strand=False, overlap=0.0)`

--- a/src/bedFile.cpp
+++ b/src/bedFile.cpp
@@ -67,6 +67,15 @@ void BedFile::Open(void) {
     }
 }
 
+// Rewind the pointer back to the beginning of the file
+void BedFile::Rewind(void) {
+    _bedStream->seekg(0, ios::beg);
+}
+
+// Jump to a specific byte in the file
+void BedFile::Seek(unsigned long offset) {
+    _bedStream->seekg(offset);
+}
 
 // Close the BED file
 void BedFile::Close(void) {

--- a/src/bedFile.h
+++ b/src/bedFile.h
@@ -274,6 +274,12 @@ public:
     
     // Open a BED file for reading (creates an istream pointer)
     void Open(void);
+
+    // Rewind the pointer back to the beginning of the file
+    void Rewind(void);
+
+    // Jump to a specific byte in the file
+    void Seek(unsigned long offset);
     
     // Close an opened BED file.
     void Close(void);


### PR DESCRIPTION
Hi Ryan,

I added two new methods to the IntervalFile class that allow one to rewind to the beginning of the file and seek to a specific offset in the file, respectively.  I needed this for the linesweep indexing stuff I've been working on. Moreover, this is functionality that just _should_ be there for supporting the reading of files.
