### PR TITLE
Multiprocessed randomintersect and randomstats

### DIFF
--- a/pybedtools/helpers.py
+++ b/pybedtools/helpers.py
@@ -365,3 +365,16 @@ def _cleanup_process(process):
 
 
 atexit.register(cleanup)
+
+
+def _call_randomintersect(_self, other, iterations, intersect_kwargs,
+                          shuffle_kwargs, debug, report_iterations):
+    """
+    Helper function that list-ifies the output from randomintersection, s.t.
+    it can be pickled across a multiprocess Pool.
+    """
+    return list(_self.randomintersection(other, iterations,
+                                        intersect_kwargs=intersect_kwargs,
+                                        shuffle_kwargs=shuffle_kwargs,
+                                        report_iterations=report_iterations,
+                                        debug=False, processes=1))


### PR DESCRIPTION
Added multiprocessing support so I can break up large randomintersect jobs into many subprocesses.  Just specify `processes=N` as a kwarg for either `BedTool.randomintersection` or `BedTool.randomstats`
