### PR TITLE
Add as_string option for BedTool.head()

### DIFF
--- a/pybedtools/bedtool.py
+++ b/pybedtools/bedtool.py
@@ -836,9 +836,9 @@ class BedTool(object):
     def __sub__(self, other):
         return self.intersect(other, v=True)
 
-    def head(self, n=10):
+    def head(self, n=10, as_string=False):
         """
-        Prints the first *n* lines
+        Prints the first *n* lines or returns them if as_string is True
 
         >>> a = pybedtools.example_bedtool('a.bed')
         >>> a.head(2) #doctest: +NORMALIZE_WHITESPACE
@@ -850,10 +850,13 @@ class BedTool(object):
         if not isinstance(self.fn, basestring):
             raise NotImplementedError('head() not supported for non file-based'
                     'BedTools')
-        for i, line in enumerate(iter(self)):
-            if i == (n):
-                break
-            print line
+        if as_string:
+            return '\n'.join(str(line) for line in self[:n]) + '\n'
+        else:
+            for i, line in enumerate(iter(self)):
+                if i == (n):
+                    break
+                print line
 
     def set_chromsizes(self, chromsizes):
         """


### PR DESCRIPTION
The motivation being that if I just want a slice of a bedtool, I can do:

```
b = pybedtools.BedTool(a.head(3, as_string=True), from_string=True)
```

Other options I tried include `b = pybedtools.BedTool(a[:3])` which makes a streaming bedtool:

```
In [7]: print b
chr1    1       100     feature1        0       +
chr1    100     200     feature2        0       +
chr1    150     500     feature3        0       -
In [8]: print b
  # nothing here!
```

and `b = pybedtools.BedTool(list(a[:3])` which should work according to the docstring but actually results in:

```
In [12]: repr(b)
Out[12]: '[Interval(chr1:1-100), Interval(chr1:100-200), Interval(chr1:150-500)]'
In [13]: str(b)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
/home/wbiesing/src/pybedtools/<ipython-input-15-a97e8db495c5> in <module>()
----> 1 str(b)
/home/wbiesing/src/pybedtools/pybedtools/bedtool.py in __str__(self)
    802             return open(self.fn).read()
    803 
--> 804         return '\n'.join(str(i) for i in iter(self)) + '\n'
    805 
    806     def __len__(self):

TypeError: iter() returned non-iterator of type 'list'
```

Perhaps I can just live with `'\n'.join(map(str, a[:1000]))`.
