### PR TITLE
GFF Attributes improvment

### DIFF
--- a/pybedtools/cbedtools.pyx
+++ b/pybedtools/cbedtools.pyx
@@ -126,7 +126,7 @@ cdef class Attributes(dict):
 
         self.sep, self.field_sep = (";", "=") if "=" in attr_str else (";", " ")
         kvs = map(str.strip, attr_str.strip().split(self.sep))
-        for field, value in [kv.split(self.field_sep) for kv in kvs if kv]:
+        for field, value in [kv.split(self.field_sep, 1) for kv in kvs if kv]:
             self[field] = value.replace('"', '')
 
     def __setitem__(self, key, value):


### PR DESCRIPTION
made attributes a proper `dict`, so `in` and `del` work as expected

added small improvment so the parser does not break on improper attrs format (unescaped = chars)
