### PR TITLE
Use a more robust detection for samtools

### DIFF
--- a/pybedtools/helpers.py
+++ b/pybedtools/helpers.py
@@ -136,13 +136,16 @@ def isBAM(fn):
 
     cmds = ['samtools', 'view', '-H', fn]
     try:
-        p = subprocess.Popen(
-            cmds, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        stdout, stderr = p.communicate()
-        if stderr:
-            return False
 
+        # Silence the output, we want to check the return code
+        with open(os.devnull, "w") as out:
+            subprocess.check_call(cmds, stdout=out, stderr=out)
         return True
+
+    except subprocess.CalledProcessError:
+        # Non-0 return code, it means we have an error
+        return False
+
     except OSError:
         raise OSError(
             'SAMtools (http://samtools.sourceforge.net/) '


### PR DESCRIPTION
isSAM() currently fails when using forks of samtools that write to stderr. In fact, checking for any stderr output is not very robust: this commit fixes the issue by using subprocess.check_call() and catching the exception in case the command does not return 0.

I tested it locally, works.
