### PR TITLE
fix cbedtools.Attributes initialization

### DIFF
--- a/pybedtools/cbedtools.pyx
+++ b/pybedtools/cbedtools.pyx
@@ -117,6 +117,8 @@ cdef class Attributes(dict):
         else:
             self.sep, self.field_sep = (';', ' ')
 
+        self._quoted = {}
+
         # TODO: pathological case . . . detect this as GFF:
         #
         #   class_code=" "
@@ -129,7 +131,6 @@ cdef class Attributes(dict):
         if attr_str == "":
             return
 
-        self._quoted = {}
         kvs = map(str.strip, attr_str.strip().split(self.sep))
         for field, value in [kv.split(self.field_sep, 1) for kv in kvs if kv]:
             if value.count('"') == 2:


### PR DESCRIPTION
When `cbedtools.Attributes()` is used to create a new object, instead of parsing some existing string, `self._quoted` is not initialized properly and as a consequence, `__str__()` method does not work.

Current workaround is to pass e. g. a single space as argument to the constructor.
