### PR TITLE
Skip tests that are not broken

### DIFF
--- a/pybedtools/test/test1.py
+++ b/pybedtools/test/test1.py
@@ -1333,6 +1333,10 @@ def test_reldist():
     chr1	150	500	feature3	0	-	0.220""")
 
 def test_remote_bam():
+    from nose.plugins.skip import SkipTest
+    raise SkipTest('Known failure: The URL ftp://ftp-trace.ncbi.nih.gov/1000genomes/ftp/data/HG00096/'
+                   'exome_alignment/HG00096.chrom11.ILLUMINA.bwa.GBR.exome.'
+                   '20120522.bam does not exist')
     x = pybedtools.BedTool(
         ('ftp://ftp-trace.ncbi.nih.gov/1000genomes/ftp/data/HG00096/'
          'exome_alignment/HG00096.chrom11.ILLUMINA.bwa.GBR.exome.'

--- a/pybedtools/test/test1.py
+++ b/pybedtools/test/test1.py
@@ -1393,7 +1393,8 @@ def test_to_dataframe():
     try:
         import pandas
     except ImportError:
-        print("pandas not installed; skipping test")
+        from nose.plugins.skip import SkipTest
+        raise SkipTest("pandas not installed; skipping test")
 
     a = pybedtools.example_bedtool('a.bed')
 


### PR DESCRIPTION
This PR skips the following tests:

1. `test_to_dataframe`, if `pandas` is not installed. Previously the test would just print the message, but still fail.
2. `test_remote_bam`, as the URI resolved is not available any more see #134 
3.  The `gchart` saving to PNG. Namely I skip the PNG comparison step, but still perform the metadata checking (see diff attached).

The reason for skipping the PNG check is that while the generated images look identical for eye, they still differ pixel by pixel. 
Particularly, see the generated image below, and the diff between it and the answer generated using `ImageMagick`

Generated output `gchart_out.png`
![gchart_out.png](http://i.imgur.com/kaxUP54.png?1)

Diff (`compare gchart_out.png pybedtools/test/gchart-expected.png -compose src diff.png`)
![diff.png](http://i.imgur.com/9E4h8yy.png)

