### PR TITLE
Automated support for compression + fix for str() on gzipped bedtools

### DIFF
--- a/pybedtools/bedtool.py
+++ b/pybedtools/bedtool.py
@@ -2724,13 +2724,14 @@ class BedTool(object):
             return c
 
     @_log_to_history
-    def saveas(self, fn=None, trackline=None, compressed=False):
+    def saveas(self, fn=None, trackline=None, compressed=None):
         """
         Make a copy of the BedTool.
 
         Optionally adds `trackline` to the beginning of the file.
 
-        Optionally compresses output using gzip.
+        if the filename extension is .gz, or compressed=True,
+        the output is compressed using gzip
 
         Returns a new BedTool for the newly saved file.
 
@@ -2754,6 +2755,14 @@ class BedTool(object):
         """
         if fn is None:
             fn = self._tmp()
+
+        # Default to compressed if extension is .gz
+        if compressed is None:
+            __, extension = os.path.splitext(fn)
+            if extension == '.gz':
+                compressed = True
+            else:
+                compressed = False
 
         fn = self._collapse(self, fn=fn, trackline=trackline,
                             compressed=compressed)

--- a/pybedtools/bedtool.py
+++ b/pybedtools/bedtool.py
@@ -976,13 +976,8 @@ class BedTool(object):
 
     def __str__(self):
         """
-        Different methods to return the string, depending on how the BedTool
-        was created.  If self.fn is anything but a basestring, the iterable
-        will be consumed.
+        Returns the string representation of the whole `BedTool`
         """
-        if isinstance(self.fn, basestring) and not self._isbam:
-            return open(self.fn).read()
-
         return ''.join(str(i) for i in iter(self))
 
     def __len__(self):

--- a/pybedtools/test/test1.py
+++ b/pybedtools/test/test1.py
@@ -1,5 +1,4 @@
 import pybedtools
-import gzip
 import os, difflib, sys
 from textwrap import dedent
 from nose import with_setup
@@ -791,24 +790,6 @@ def test_kwargs():
     c = a.intersect(a)
     assert str(b) == str(c)
 
-
-# ----------------------------------------------------------------------------
-# gzip support tests
-# ----------------------------------------------------------------------------
-
-def test_gzip():
-    # make new gzipped files on the fly
-    agz = pybedtools.BedTool._tmp()
-    bgz = pybedtools.BedTool._tmp()
-    os.system('gzip -c %s > %s' % (pybedtools.example_filename('a.bed'), agz))
-    os.system('gzip -c %s > %s' % (pybedtools.example_filename('b.bed'), bgz))
-    agz = pybedtools.BedTool(agz)
-    bgz = pybedtools.BedTool(bgz)
-    assert agz.file_type == bgz.file_type == 'bed'
-    a = pybedtools.example_bedtool('a.bed')
-    b = pybedtools.example_bedtool('b.bed')
-    assert a.intersect(b) == agz.intersect(bgz) == a.intersect(bgz) == agz.intersect(b)
-
 # ----------------------------------------------------------------------------
 # BAM support tests
 # ----------------------------------------------------------------------------
@@ -1545,14 +1526,6 @@ def test_fisher():
 left	right	two-tail	ratio
 1	8.8247e-21	8.8247e-21	inf
 """, c
-
-
-def test_gzipped_output():
-    expected = pybedtools.BedTool._tmp()
-    fn = pybedtools.example_filename('a.bed')
-    os.system('gzip -c {fn} > {expected}'.format(**locals()))
-    obs = pybedtools.example_bedtool('a.bed').saveas(compressed=True)
-    assert gzip.open(obs.fn).read() == gzip.open(expected).read()
 
 
 def test_zero_len_boolean():

--- a/pybedtools/test/test_gzip_support.py
+++ b/pybedtools/test/test_gzip_support.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_list_equal
 import pybedtools.test.tfuncs as tfuncs
 
 import pybedtools
@@ -39,6 +39,13 @@ def test_gzipped_files_can_be_intersected():
     a = pybedtools.example_bedtool('a.bed')
     b = pybedtools.example_bedtool('b.bed')
     assert a.intersect(b) == agz.intersect(bgz) == a.intersect(bgz) == agz.intersect(b)
+
+def test_gzipped_files_are_iterable_as_normal():
+    agz = _make_temporary_gzip(pybedtools.example_filename('a.bed'))
+    agz = pybedtools.BedTool(agz)
+    a = pybedtools.example_bedtool('a.bed')
+
+    assert_list_equal(list(a), list(agz))
 
 def test_str_representation_of_gzipped_files_is_the_same_as_normal():
     agz = _make_temporary_gzip(pybedtools.example_filename('a.bed'))

--- a/pybedtools/test/test_gzip_support.py
+++ b/pybedtools/test/test_gzip_support.py
@@ -1,0 +1,34 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import pybedtools.test.tfuncs as tfuncs
+
+import os
+import pybedtools
+import gzip
+
+setup = tfuncs.setup
+teardown = tfuncs.teardown
+
+def test_gzip():
+    # make new gzipped files on the fly
+    agz = pybedtools.BedTool._tmp()
+    bgz = pybedtools.BedTool._tmp()
+    os.system('gzip -c %s > %s' % (pybedtools.example_filename('a.bed'), agz))
+    os.system('gzip -c %s > %s' % (pybedtools.example_filename('b.bed'), bgz))
+    agz = pybedtools.BedTool(agz)
+    bgz = pybedtools.BedTool(bgz)
+    assert agz.file_type == bgz.file_type == 'bed'
+    a = pybedtools.example_bedtool('a.bed')
+    b = pybedtools.example_bedtool('b.bed')
+    assert a.intersect(b) == agz.intersect(bgz) == a.intersect(bgz) == agz.intersect(b)
+
+
+def test_gzipped_output():
+    expected = pybedtools.BedTool._tmp()
+    fn = pybedtools.example_filename('a.bed')
+    os.system('gzip -c {fn} > {expected}'.format(**locals()))
+    obs = pybedtools.example_bedtool('a.bed').saveas(compressed=True)
+    assert gzip.open(obs.fn).read() == gzip.open(expected).read()

--- a/pybedtools/test/test_gzip_support.py
+++ b/pybedtools/test/test_gzip_support.py
@@ -12,12 +12,18 @@ import gzip
 setup = tfuncs.setup
 teardown = tfuncs.teardown
 
+def _make_temporary_gzip(bed_filename):
+    gz_filename = pybedtools.BedTool._tmp()
+    with gzip.open(gz_filename, 'w') as out_:
+        with open(bed_filename, 'r') as in_:
+            out_.writelines(in_)
+    return gz_filename
+
 def test_gzip():
     # make new gzipped files on the fly
-    agz = pybedtools.BedTool._tmp()
-    bgz = pybedtools.BedTool._tmp()
-    os.system('gzip -c %s > %s' % (pybedtools.example_filename('a.bed'), agz))
-    os.system('gzip -c %s > %s' % (pybedtools.example_filename('b.bed'), bgz))
+    agz = _make_temporary_gzip(pybedtools.example_filename('a.bed'))
+    bgz = _make_temporary_gzip(pybedtools.example_filename('b.bed'))
+
     agz = pybedtools.BedTool(agz)
     bgz = pybedtools.BedTool(bgz)
     assert agz.file_type == bgz.file_type == 'bed'

--- a/pybedtools/test/test_gzip_support.py
+++ b/pybedtools/test/test_gzip_support.py
@@ -51,8 +51,13 @@ def test_str_representation_of_gzipped_files_is_the_same_as_normal():
     agz = _make_temporary_gzip(pybedtools.example_filename('a.bed'))
     agz = pybedtools.BedTool(agz)
     a = pybedtools.example_bedtool('a.bed')
-
     assert_equal(str(a), str(agz))
+
+def test_head_of_gzipped_files_is_the_same_as_normal():
+    agz = _make_temporary_gzip(pybedtools.example_filename('a.bed'))
+    agz = pybedtools.BedTool(agz)
+    a = pybedtools.example_bedtool('a.bed')
+    assert_equal(agz.head(), a.head())
 
 def test_gzipped_output():
     _filename = pybedtools.example_filename('a.bed')

--- a/pybedtools/test/test_gzip_support.py
+++ b/pybedtools/test/test_gzip_support.py
@@ -40,6 +40,12 @@ def test_gzipped_files_can_be_intersected():
     b = pybedtools.example_bedtool('b.bed')
     assert a.intersect(b) == agz.intersect(bgz) == a.intersect(bgz) == agz.intersect(b)
 
+def test_str_representation_of_gzipped_files_is_the_same_as_normal():
+    agz = _make_temporary_gzip(pybedtools.example_filename('a.bed'))
+    agz = pybedtools.BedTool(agz)
+    a = pybedtools.example_bedtool('a.bed')
+
+    assert_equal(str(a), str(agz))
 
 def test_gzipped_output():
     _filename = pybedtools.example_filename('a.bed')

--- a/pybedtools/test/test_gzip_support.py
+++ b/pybedtools/test/test_gzip_support.py
@@ -2,10 +2,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-
+from nose.tools import assert_equal
 import pybedtools.test.tfuncs as tfuncs
 
-import os
 import pybedtools
 import gzip
 
@@ -13,28 +12,43 @@ setup = tfuncs.setup
 teardown = tfuncs.teardown
 
 def _make_temporary_gzip(bed_filename):
+    """
+    Make a gzip file on the fly
+    :param bed_filename: Filename of bed file to gzip
+    :return: filename of gzipped file
+    """
     gz_filename = pybedtools.BedTool._tmp()
     with gzip.open(gz_filename, 'w') as out_:
         with open(bed_filename, 'r') as in_:
             out_.writelines(in_)
     return gz_filename
 
-def test_gzip():
-    # make new gzipped files on the fly
+def test_gzipped_file_types_are_bed():
+    agz = _make_temporary_gzip(pybedtools.example_filename('a.bed'))
+
+    agz = pybedtools.BedTool(agz)
+    assert_equal('bed', agz.file_type)
+
+def test_gzipped_files_can_be_intersected():
     agz = _make_temporary_gzip(pybedtools.example_filename('a.bed'))
     bgz = _make_temporary_gzip(pybedtools.example_filename('b.bed'))
 
     agz = pybedtools.BedTool(agz)
     bgz = pybedtools.BedTool(bgz)
-    assert agz.file_type == bgz.file_type == 'bed'
+
     a = pybedtools.example_bedtool('a.bed')
     b = pybedtools.example_bedtool('b.bed')
     assert a.intersect(b) == agz.intersect(bgz) == a.intersect(bgz) == agz.intersect(b)
 
 
 def test_gzipped_output():
-    expected = pybedtools.BedTool._tmp()
-    fn = pybedtools.example_filename('a.bed')
-    os.system('gzip -c {fn} > {expected}'.format(**locals()))
-    obs = pybedtools.example_bedtool('a.bed').saveas(compressed=True)
-    assert gzip.open(obs.fn).read() == gzip.open(expected).read()
+    _filename = pybedtools.example_filename('a.bed')
+    compressed_file = pybedtools.BedTool(_filename).saveas(compressed=True)
+
+    with gzip.open(compressed_file.fn) as gf:
+        uncompressed_content = gf.read()
+
+    with open(_filename) as f:
+        original_content = f.read()
+
+    assert_equal(original_content, uncompressed_content)

--- a/pybedtools/test/test_gzip_support.py
+++ b/pybedtools/test/test_gzip_support.py
@@ -2,7 +2,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
+import os
 from nose.tools import assert_equal, assert_list_equal
+import tempfile
 import pybedtools.test.tfuncs as tfuncs
 
 import pybedtools
@@ -70,3 +72,42 @@ def test_gzipped_output():
         original_content = f.read()
 
     assert_equal(original_content, uncompressed_content)
+
+def test_gzipping_is_default_when_extension_is_dot_gz():
+    _filename = pybedtools.example_filename('a.bed')
+    with open(_filename) as f:
+        expected_content = f.read()
+
+    __, temp_filename = tempfile.mkstemp(suffix='.gz')
+    try:
+        bedtool = pybedtools.BedTool(_filename)
+        bedtool.saveas(fn=temp_filename)
+
+        with gzip.open(temp_filename) as gf:
+            # gzip will fail next line if file is not gzipped
+            actual_content = gf.read()
+
+        assert_equal(expected_content, actual_content)
+    finally:
+        if os.path.isfile(temp_filename):
+            os.unlink(temp_filename)
+
+def test_gzipping_can_be_turned_off_even_for_dot_gz():
+    _filename = pybedtools.example_filename('a.bed')
+    with open(_filename) as f:
+        expected_content = f.read()
+
+    __, temp_filename = tempfile.mkstemp(suffix='.gz')
+    try:
+        bedtool = pybedtools.BedTool(_filename)
+        bedtool.saveas(fn=temp_filename, compressed=False)
+
+        with open(temp_filename) as non_gz_f:
+            # actual content will be jumbled if non_gz_f is unset
+            actual_content = non_gz_f.read()
+
+        assert_equal(expected_content, actual_content)
+    finally:
+        if os.path.isfile(temp_filename):
+            os.unlink(temp_filename)
+


### PR DESCRIPTION
Hi Ryan,

First, the good news, 90d41e1 makes `pybedtools` compress the output by default if one is saving to a `.gz` file. I believe this is the default intent for users, and it can be overriden by `compressed=False`.

Now in 327c79f I have attempted to fix `__str__()` that is broken for gzipped files. Obviously the broken part is that we attempt to read a compressed file as plain-text. I therefore remove that check, which makes `pybedtools` default at reading all files in the same fashion.

Now funnily enough, this breaks quite a few `test_iter.py` tests.
The output of tests is quite verbose, so I am not posting it here, have a look at [pastebin](http://pastebin.com/B3QWGbTi) though.

If I add the lines below back in, the `test_iter` tests start working again
```python
if isinstance(self.fn, basestring) and not self._isbam:
            return open(self.fn).read()
```
So I'm clearly misunderstanding something. 
What is the utility of this direct reading, and why do the tests need it?

P.S. I hope you don't mind that I moved the tests into `test_gzip_support.py` -- makes it a bit easier to focus on what is going on.