### PR TITLE
cat: handle empty input files

### DIFF
--- a/pybedtools/bedtool.py
+++ b/pybedtools/bedtool.py
@@ -2776,7 +2776,6 @@ class BedTool(object):
         # postmerge and force_trucate don't get passed on to merge
         postmerge = kwargs.pop('postmerge', True)
         force_truncate = kwargs.pop('force_truncate', False)
-
         stream_merge = kwargs.get('stream', False)
         if stream_merge and postmerge:
             raise ValueError(
@@ -2796,7 +2795,7 @@ class BedTool(object):
                     + [i.file_type for i in other_beds]).difference(['empty'])
                 field_nums = set(
                     [self.field_count()]
-                    + [i.field_count() for i in other_beds]).difference([None])
+                    + [i.field_count() for i in other_beds]).difference([None]).difference([0])
                 same_field_num = len(field_nums) == 1
                 same_type = len(set(filetypes)) == 1
             except ValueError:

--- a/pybedtools/test/test1.py
+++ b/pybedtools/test/test1.py
@@ -723,6 +723,19 @@ def test_cat():
     chr1	800	901	feature6	0	+
     """)
 
+    b_expected = fix("""
+    chr1	155	200	feature5	0	-
+    chr1	800	901	feature6	0	+
+    """)
+    b_merge_expected = fix("""
+    chr1	155	200
+    chr1	800	901
+    """)
+    empty = pybedtools.BedTool([])
+    assert b.cat(empty) == b_merge_expected
+    assert empty.cat(b) == b_merge_expected
+    assert b.cat(empty, postmerge=False)== b_expected
+    assert empty.cat(b, postmerge=False)== b_expected
 
 def test_issue_138():
     x = pybedtools.BedTool(


### PR DESCRIPTION
The latest release (0.7.2) has an issue with bedtools cat on empty files
due to fixes for #138 (https://github.com/daler/pybedtools/commit/08a07378200906dbc75c2c87413d56e9bad8ff94).
Passing an empty file to cat will result in field_nums having a 0, and
the new minfields check will eliminate all of the fields in the
non-emtpy files.

This has the small fix for that plus a test case to catch it.