### PR TITLE
Dont raise error if len(_names) < self.field_count()

### DIFF
--- a/pybedtools/bedtool.py
+++ b/pybedtools/bedtool.py
@@ -14,6 +14,7 @@ import multiprocessing
 import six
 import gzip
 import pysam
+from warnings import warn
 
 from .helpers import (
     get_tempdir, _tags, call_bedtools, _flatten_list, _check_sequence_stderr,
@@ -3191,9 +3192,10 @@ class BedTool(object):
                 _names = \
                     settings._column_names[self.file_type][:self.field_count()]
                 if len(_names) < self.field_count():
-                    raise ValueError(
+                    _names = None
+                    warn(
                         'Default names for filetype %s are:\n%s\nbut file has '
-                        '%s fields; please supply custom names with the '
+                        '%s fields; you can supply custom names with the '
                         '`names` kwarg'
                         % (self.file_type, _names, self.field_count()))
             except KeyError:

--- a/pybedtools/bedtool.py
+++ b/pybedtools/bedtool.py
@@ -3192,12 +3192,12 @@ class BedTool(object):
                 _names = \
                     settings._column_names[self.file_type][:self.field_count()]
                 if len(_names) < self.field_count():
-                    _names = None
                     warn(
                         'Default names for filetype %s are:\n%s\nbut file has '
                         '%s fields; you can supply custom names with the '
                         '`names` kwarg'
                         % (self.file_type, _names, self.field_count()))
+                    _names = None
             except KeyError:
                 _names = None
 

--- a/pybedtools/test/test1.py
+++ b/pybedtools/test/test1.py
@@ -17,6 +17,7 @@ from six.moves import socketserver
 from six.moves import BaseHTTPServer
 
 import threading
+import warnings
 
 
 
@@ -1655,7 +1656,13 @@ def test_to_dataframe():
     # get a gff file with too many fields...
     x = pybedtools.example_bedtool('c.gff')
     x = x.intersect(x, c=True)
-    assert_raises(ValueError, x.to_dataframe)
+    with warnings.catch_warnings(record=True) as w:
+        #trigger the warning
+        x.to_dataframe()
+        #assert a few things
+        assert len(w) == 1
+        assert issubclass(w[-1].category, UserWarning)
+        assert str(w[-1].message).startswith('Default names for filetype')
 
     names = ['seqname', 'source', 'feature', 'start', 'end', 'score', 'strand',
              'frame', 'attributes', 'count']


### PR DESCRIPTION
Hi,

I run into this error all the time when converting to dataframe.
Since pandas is more than happy to deal with names=None, I find raising an error here quite unnecessary.

I changed the error to a warning, and let it pass _names=None when the default names don't fit.