### PR TITLE
Fix intron creation from gff file

### DIFF
--- a/pybedtools/bedtool.py
+++ b/pybedtools/bedtool.py
@@ -890,8 +890,8 @@ class BedTool(object):
         # iterate over all the features in the gene.
         s = self.sort()
         if self.file_type == "gff":
-            exon_iter = BedTool((f for f in s if f[2] == gene)).saveas()
-            gene_iter = BedTool((f for f in s if f[2] == exon)).saveas()
+            exon_iter = BedTool((f for f in s if f[2] == exon)).saveas()
+            gene_iter = BedTool((f for f in s if f[2] == gene)).saveas()
 
         elif self.file_type == "bed":
             if s.field_count() == 12:


### PR DESCRIPTION
exon_iter actually iterate through genes and gene_iter iterates through exons. It should be the opposite.
This fix simply swap the filter expression