### PR TITLE
Fix `truncate_to_chrom`, open file for writing string, not bytes

### DIFF
--- a/pybedtools/bedtool.py
+++ b/pybedtools/bedtool.py
@@ -592,7 +592,7 @@ class BedTool(object):
             chromdict = helpers.chromsizes(genome)
 
         tmp = self._tmp()
-        fout = open(tmp, 'wb')
+        fout = open(tmp, 'w')
         for chrom, coords in list(chromdict.items()):
             start, stop = coords
             start = str(start)


### PR DESCRIPTION
Fixes #203 