### PR TITLE
Permit fetching of full chromosome

### DIFF
--- a/pybedtools/bedtool.py
+++ b/pybedtools/bedtool.py
@@ -8,7 +8,6 @@ import os
 import sys
 import random
 import string
-import re
 import pprint
 from itertools import islice
 import multiprocessing
@@ -620,8 +619,6 @@ class BedTool(object):
         # pass zero-based directly to the pysam tabix interface.
         tbx = pysam.TabixFile(self.fn)
 
-        coord_re = re.compile(r"(.+):(\d+)-(\d+)?", re.VERBOSE)
-
         # If an interval is passed, use its coordinates directly
         if isinstance(interval_or_string, Interval):
             interval = interval_or_string
@@ -629,7 +626,7 @@ class BedTool(object):
         # Parse string directly instead of relying on Interval, in order to
         # permit full chromosome fetching
         else:
-            match = coord_re.search(interval_or_string)
+            match = helpers.coord_re.search(interval_or_string)
             # Assume string is contig if it doesn't fit chrom:start-end format
             if match is None:
                 chrom = interval_or_string

--- a/pybedtools/bedtool.py
+++ b/pybedtools/bedtool.py
@@ -617,9 +617,24 @@ class BedTool(object):
         # tabix expects 1-based coords, but BEDTools works with
         # zero-based. pybedtools and pysam also work with zero-based. So we can
         # pass zero-based directly to the pysam tabix interface.
-        interval = helpers.string_to_interval(interval_or_string)
         tbx = pysam.TabixFile(self.fn)
-        results = tbx.fetch(str(interval.chrom), interval.start, interval.stop)
+
+        # If an interval is passed, use its coordinates directly
+        if isinstance(interval_or_string, Interval):
+            interval = interval_or_string
+            chrom, start, end = interval.chrom, interval.start, interval.stop
+        # Otherwise, we can't create an Interval if no start/end are specified,
+        # so parse coordinates from the region string.
+        elif ':' in interval_or_string:
+            chrom, coords = interval_or_string.split(':')
+            start, end = [int(x) for x in coords.split('-')]
+        # If no start/end specified, tabix will return full chromosome
+        else:
+            chrom = interval_or_string
+            start, end = None, None
+
+        # Fetch results.
+        results = tbx.fetch(str(chrom), start, end)
 
         # pysam.ctabix.TabixIterator does not include newlines when yielding so
         # we need to add them.

--- a/pybedtools/test/test1.py
+++ b/pybedtools/test/test1.py
@@ -152,7 +152,6 @@ def test_tabix_intervals():
 
     # permit fetching of a contig without a specified region
     assert len(a.tabix_intervals('chr1')) == 1
-    assert len(a.tabix_intervals('chr2')) == 0
 
 # ----------------------------------------------------------------------------
 # Streaming and non-file BedTool tests

--- a/pybedtools/test/test1.py
+++ b/pybedtools/test/test1.py
@@ -150,6 +150,10 @@ def test_tabix_intervals():
     assert len(a.tabix_intervals('chr1:30-35[-]')) == 0
     assert len(a.tabix_intervals('chr1:29-30[-]')) == 1
 
+    # permit fetching of a contig without a specified region
+    assert len(a.tabix_intervals('chr1')) == 1
+    assert len(a.tabix_intervals('chr2')) == 0
+
 # ----------------------------------------------------------------------------
 # Streaming and non-file BedTool tests
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Hi,

I found that `BedTool.tabix_intervals` required a region string to contain a start and end, as its coordinate parsing relied on converting the string to an `Interval`. This made it difficult to arbitrarily fetch an entire chromosome without access to a dictionary of contig lengths. 

As `TabixFile.fetch` doesn't mind being passed a chromosome with no start or end specified, I removed the coordinate parsing through `helpers.string_to_interval` and replaced it with a simple string splitting. Please let me know if you find this solution acceptable or if you have a suggestion for an alternative implementation.

Thanks!

Matt