### PR TITLE
Support comma-separated lists for mapBed

### DIFF
--- a/pybedtools/bedtool.py
+++ b/pybedtools/bedtool.py
@@ -1276,6 +1276,7 @@ class BedTool(object):
             'multiIntersectBed': ' ',
             'mergeBed': ',',
             'intersectBed': ' ',
+            'mapBed': ',',
         }
         stdin = None
 


### PR DESCRIPTION
[Bedtools map](http://bedtools.readthedocs.io/en/latest/content/tools/map.html) supports multiple arguments for columns and operations that are comma separated. This PR adds support for that; previously lists would be space separated which doesn't work.
