### PR TITLE
further set_path fixes

### DIFF
--- a/pybedtools/paths.py
+++ b/pybedtools/paths.py
@@ -5,7 +5,8 @@ This is kept separate from helpers module in order to avoid circular imports in
 setting the bedtools path.
 """
 
-from . import bedtool
+import pybedtools
+from pybedtools import bedtool
 from . import settings
 from six.moves import reload_module
 
@@ -15,6 +16,7 @@ def _set_bedtools_path(path=""):
     settings._bedtools_path = path
     if old_path != path:
         reload_module(bedtool)
+        reload_module(pybedtools)
         return True
 
 

--- a/pybedtools/test/test1.py
+++ b/pybedtools/test/test1.py
@@ -2122,49 +2122,50 @@ def test_issue_203():
 
 def test_issue_218():
     from pybedtools.helpers import set_bedtools_path, get_bedtools_path
+    from pybedtools import BedTool
 
     orig_path = get_bedtools_path()
 
     # As pointed out in #222, example_bedtool behaves differently from BedTool.
     # example_bedtool is defined in pybedtools.bedtool but pybedtools.BedTool
-    # is imported in pybedtools.__init__. Check both of these methods as x1 and
-    # x2.
-    x1 = pybedtools.example_bedtool('x.bed')
-    x2 = pybedtools.BedTool(pybedtools.example_filename('x.bed'))
-    x1.sort()
-    x2.sort()
-    assert "Original BEDTools help" in pybedtools.bedtool.BedTool.sort.__doc__
-    assert "Original BEDTools help" in x1.sort.__doc__
-    assert "Original BEDTools help" in x2.sort.__doc__
+    # is imported in pybedtools.__init__. So check various constructors here.
+    for constructor in (
+        lambda x: pybedtools.example_bedtool(x),
+        lambda x: pybedtools.BedTool(pybedtools.example_filename(x)),
+        lambda x: pybedtools.bedtool.BedTool(pybedtools.example_filename(x)),
 
-    set_bedtools_path('nonexistent')
+        # NOTE: we likely need recursive reloading (like IPython.deepreload)
+        # for this to work:
+        #
+        # lambda x: BedTool(pybedtools.example_filename(x)),
+    ):
 
-    # the BedTool object that was previously successfully created will now have
-    # OSError...
-    assert_raises(OSError, x1.sort)
-    assert_raises(OSError, x2.sort)
+        x = constructor('x.bed')
+        x.sort()
+        assert "Original BEDTools help" in pybedtools.bedtool.BedTool.sort.__doc__
+        assert "Original BEDTools help" in x.sort.__doc__
 
-    # ...but docstring was already created for `x`, so it should stay the same.
-    # The class docstring should have been reset.
-    assert "Original BEDTools help" in x1.sort.__doc__
-    assert "Original BEDTools help" in x2.sort.__doc__
-    assert pybedtools.bedtool.BedTool.sort.__doc__ is None
+        set_bedtools_path('nonexistent')
 
-    # Creating a new BedTool object now that bedtools is not on the path should
-    # detect that, adding a method that raises NotImplementedError...
-    y1 = pybedtools.example_bedtool('x.bed')
-    y2 = pybedtools.BedTool(pybedtools.example_filename('x.bed'))
-    assert_raises(NotImplementedError, y1.sort)
-    assert_raises(NotImplementedError, y2.sort)
+        # Calling BEDTools with non-existent path, but the docstring should not
+        # have been changed.
+        assert_raises(OSError, x.sort)
+        assert "Original BEDTools help" in x.sort.__doc__
 
-    # ...and correspondingly no docstring
-    assert y1.sort.__doc__ is None
-    assert y2.sort.__doc__ is None
-    assert pybedtools.bedtool.BedTool.sort.__doc__ is None
+        # The class's docstring should have been reset though.
+        assert pybedtools.bedtool.BedTool.sort.__doc__ is None
 
-    # Reset, and ensure the resetting works
-    set_bedtools_path()
-    z1 = pybedtools.example_bedtool('x.bed')
-    z2 = pybedtools.BedTool(pybedtools.example_filename('x.bed'))
-    z1.sort()
-    z2.sort()
+        # Creating a new BedTool object now that bedtools is not on the path
+        # should detect that, adding a method that raises
+        # NotImplementedError...
+        y = constructor('x.bed')
+        assert_raises(NotImplementedError, y.sort)
+
+        # ...and correspondingly no docstring
+        assert y.sort.__doc__ is None
+        assert pybedtools.bedtool.BedTool.sort.__doc__ is None
+
+        # Reset the path, and ensure the resetting works
+        set_bedtools_path()
+        z = constructor('x.bed')
+        z.sort()

--- a/pybedtools/test/test1.py
+++ b/pybedtools/test/test1.py
@@ -2125,32 +2125,46 @@ def test_issue_218():
 
     orig_path = get_bedtools_path()
 
-    x = pybedtools.example_bedtool('x.bed')
-    x.sort()
+    # As pointed out in #222, example_bedtool behaves differently from BedTool.
+    # example_bedtool is defined in pybedtools.bedtool but pybedtools.BedTool
+    # is imported in pybedtools.__init__. Check both of these methods as x1 and
+    # x2.
+    x1 = pybedtools.example_bedtool('x.bed')
+    x2 = pybedtools.BedTool(pybedtools.example_filename('x.bed'))
+    x1.sort()
+    x2.sort()
     assert "Original BEDTools help" in pybedtools.bedtool.BedTool.sort.__doc__
-    assert "Original BEDTools help" in x.sort.__doc__
+    assert "Original BEDTools help" in x1.sort.__doc__
+    assert "Original BEDTools help" in x2.sort.__doc__
 
     set_bedtools_path('nonexistent')
 
     # the BedTool object that was previously successfully created will now have
     # OSError...
-    assert_raises(OSError, x.sort)
+    assert_raises(OSError, x1.sort)
+    assert_raises(OSError, x2.sort)
 
     # ...but docstring was already created for `x`, so it should stay the same.
     # The class docstring should have been reset.
-    assert "Original BEDTools help" in x.sort.__doc__
+    assert "Original BEDTools help" in x1.sort.__doc__
+    assert "Original BEDTools help" in x2.sort.__doc__
     assert pybedtools.bedtool.BedTool.sort.__doc__ is None
 
     # Creating a new BedTool object now that bedtools is not on the path should
     # detect that, adding a method that raises NotImplementedError...
-    y = pybedtools.example_bedtool('x.bed')
-    assert_raises(NotImplementedError, y.sort)
+    y1 = pybedtools.example_bedtool('x.bed')
+    y2 = pybedtools.BedTool(pybedtools.example_filename('x.bed'))
+    assert_raises(NotImplementedError, y1.sort)
+    assert_raises(NotImplementedError, y2.sort)
 
     # ...and correspondingly no docstring
-    assert y.sort.__doc__ is None
+    assert y1.sort.__doc__ is None
+    assert y2.sort.__doc__ is None
     assert pybedtools.bedtool.BedTool.sort.__doc__ is None
 
     # Reset, and ensure the resetting works
     set_bedtools_path()
-    z = pybedtools.example_bedtool('x.bed')
-    z.sort()
+    z1 = pybedtools.example_bedtool('x.bed')
+    z2 = pybedtools.BedTool(pybedtools.example_filename('x.bed'))
+    z1.sort()
+    z2.sort()


### PR DESCRIPTION
xref #218, #220, #221, #222 

Thanks @lonsbio for pointing out that `example_bedtool` worked but `BedTool` didn't -- until then I was stumped as to why the tests were working but issues were still being reported.

The solution here was to reload both `pybedtools.bedtool` as well as `pybedtools` as a whole. The latter is to ensure the `bedtool` module imported into `pybedtools.__init__` is reloaded as well. I thought that should have happened anyway, but I guess I hadn't fully understood how the reloading works (it's not recursive).

I also improved the test to check both `example_bedtool`-created and `pybedtools.BedTool` objects.

I haven't quite worked out how to reload when someone uses `from pybedtools import BedTool`. I suspect a deep reload (like IPython's deepreload) will be needed here. https://github.com/ipython/ipython/blob/master/IPython/lib/deepreload.py is BSD licensed at least.

@lonsbio, @jordeu, @croth1 would you mind giving this a spin? Sorry all that it's taken a while -- it's been a busy couple of weeks.