### PR TITLE
Addressed bedtools shuffle difference in test

### DIFF
--- a/pybedtools/helpers.py
+++ b/pybedtools/helpers.py
@@ -68,30 +68,37 @@ def _check_for_bedtools(program_to_check='intersectBed', force_check=False):
     if settings._bedtools_installed and not force_check:
         return True
 
-    if 0==len(settings.bedtools_version):
-        # let us quickly determine the program version by calling without specifying application
+    if len(settings.bedtools_version) == 0:
+        # let us quickly determine the program version by calling without
+        # specifying application
         try:
-            v = subprocess.check_output([os.path.join(settings._bedtools_path, 'bedtools'),'--version'])
+            v = subprocess.check_output(
+                [
+                    os.path.join(
+                        settings._bedtools_path, 'bedtools'),
+                    '--version'])
+
             settings._bedtools_installed = True
-            settings._v_2_15_plus = True
-            settings.bedtools_version = []
+
+            # e.g.,
+            #
+            #  bedtools v2.26.0
+            #
             vv = v.decode().split('v')[1]
-            for i in vv.split("."):
-                settings.bedtools_version.append(int(i))
-            if settings.bedtools_version[0]>2:
-                settings._v_2_27_plus = True
-                settings._v_2_15_plus = True
-            elif settings.bedtools_version[0]>=2 and settings.bedtools_version[1]>=27:
-                settings._v_2_27_plus = True
-                settings._v_2_15_plus = True
-            elif settings.bedtools_version[0]>=2 and settings.bedtools_version[1]>=15:
-                settings._v_2_27_plus = False
-                settings._v_2_15_plus = True
-            else:
-                settings._v_2_27_plus = False
-                settings._v_2_15_plus = False
-            #print("Found BEDtools installed, settings._v_2_27_plus=%d, settings._v_2_15_plus=%d\n" % (settings._v_2_27_plus,settings._v_2_15_plus))
-        except(subprocess.CalledProcessError):
+
+            settings.bedtools_version = [int(i) for i in vv.split(".")]
+
+            settings._v_2_27_plus = (
+                settings.bedtools_version[0] >= 2 and
+                settings.bedtools_version[1] >= 27
+            )
+
+            settings._v_2_15_plus = (
+                settings.bedtools_version[0] >= 2 and
+                settings.bedtools_version[1] >= 15
+            )
+
+        except subprocess.CalledProcessError:
             if settings._bedtools_path:
                 add_msg = "(tried path '%s')" % settings._bedtools_path
             else:
@@ -100,27 +107,33 @@ def _check_for_bedtools(program_to_check='intersectBed', force_check=False):
                           "(https://github.com/arq5x/bedtools) and that "
                           "it's on the path. %s" % add_msg)
 
-    try:
-        p = subprocess.Popen(
-            [os.path.join(settings._bedtools_path, 'bedtools'),
-             settings._prog_names[program_to_check]],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        settings._bedtools_installed = True
-        settings._v_2_15_plus = True
+    # Disabling the additional pre-2.15 check since the above code is now
+    # handling it based on what --version reports.
+    #
+    # TODO: fully deprecate this, and eventually remove v2.15 support.
+    #
+    # try:
+    #     p = subprocess.Popen(
+    #         [os.path.join(settings._bedtools_path, 'bedtools'),
+    #          settings._prog_names[program_to_check]],
+    #         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    #     settings._bedtools_installed = True
+    #     settings._v_2_15_plus = True
+    #     settings._v_2_27_plus = False
 
-    except (OSError, KeyError) as err:
-        try:
-            p = subprocess.Popen(
-                [os.path.join(settings._bedtools_path, program_to_check)],
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            settings._bedtools_installed = True
-            settings._v_2_15_plus = False
+    # except (OSError, KeyError) as err:
+    #     try:
+    #         p = subprocess.Popen(
+    #             [os.path.join(settings._bedtools_path, program_to_check)],
+    #             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    #         settings._bedtools_installed = True
+    #         settings._v_2_15_plus = False
 
-        except OSError as err:
-            if err.errno == 2:
-                raise OSError("BEDTools exists as a binary but seems otherwise incompatible. "
-                              "Please check that what is installed in '%s' is indeed from "
-                              "https://github.com/arq5x/bedtools." % settings._bedtools_path)
+    #     except OSError as err:
+    #         if err.errno == 2:
+    #             raise OSError("BEDTools exists as a binary but seems otherwise incompatible. "
+    #                           "Please check that what is installed in '%s' is indeed from "
+    #                           "https://github.com/arq5x/bedtools." % settings._bedtools_path)
 
 def _check_for_R():
     try:

--- a/pybedtools/settings.py
+++ b/pybedtools/settings.py
@@ -4,12 +4,13 @@ _R_path = ""
 tempfile_prefix = 'pybedtools.'
 tempfile_suffix = '.tmp'
 
-
 # Checking for BEDTools will happen when creating the first BedTool; other
 # checks happen at first use (BAM object creation; tabix-ing a BedTool)
 _bedtools_installed = False
 _R_installed = False
 _v_2_15_plus = False
+_v_2_27_plus = False
+bedtools_version = []
 
 KEEP_TEMPFILES = False
 _DEBUG = True

--- a/pybedtools/test/test1.py
+++ b/pybedtools/test/test1.py
@@ -2051,6 +2051,14 @@ def test_issue_196():
 
 
 def test_issue_178():
+
+    # Compatibility between py2/py3: py27 does not have FileNotFoundError, so
+    # set it to IOError (which does exist) for this function.
+    try:
+        FileNotFoundError
+    except NameError:
+        FileNotFoundError = IOError
+
     try:
         fn = pybedtools.example_filename('gdc.othersort.bam')
         pybedtools.contrib.bigwig.bam_to_bigwig(fn, genome='dm3', output='tmp.bw')

--- a/pybedtools/test/test1.py
+++ b/pybedtools/test/test1.py
@@ -1610,25 +1610,17 @@ def test_to_dataframe():
 
     a = pybedtools.example_bedtool('a.bed')
 
-    results = str(a.to_dataframe())
-
-
-
-    expected = fix_dataframe("""
-  chrom  start  end      name  score strand
-0  chr1      1  100  feature1      0      +
-1  chr1    100  200  feature2      0      +
-2  chr1    150  500  feature3      0      -
-3  chr1    900  950  feature4      0      +""")
-    assert results == expected
-
+    results = a.to_dataframe()
+    assert results.loc[0, 'name'] == 'feature1'
+    assert list(results.columns) == ['chrom', 'start', 'end', 'name', 'score', 'strand']
+    assert results.loc[3, 'strand'] == '+'
 
     # reverse should work, too:
     df = a.to_dataframe()
     a2 = pybedtools.BedTool.from_dataframe(df)
     assert a2 == a
 
-    # try only part of the dataframe
+    # try converting only part of the dataframe to a BedTool
     a3 = pybedtools.BedTool.from_dataframe(
         df.ix[df.start < 100, ['chrom', 'start', 'end', 'name']]
     )
@@ -1638,23 +1630,12 @@ def test_to_dataframe():
         """), str(a3)
 
     d = pybedtools.example_bedtool('d.gff')
-    results = str(d.to_dataframe())
-    expected = fix_dataframe("""
-  seqname source feature  start   end score strand frame  \\
-0    chr1   fake    gene     50   300     .      +     .   
-1    chr1   fake    mRNA     50   300     .      +     .   
-2    chr1   fake     CDS     75   150     .      +     .   
-3    chr1   fake     CDS    200   275     .      +     .   
-4    chr1   fake    rRNA   1200  1275     .      +     .   
-
-               attributes  
-0                ID=gene1  
-1  ID=mRNA1;Parent=gene1;  
-2   ID=CDS1;Parent=mRNA1;  
-3   ID=CDS2;Parent=mRNA1;  
-4               ID=rRNA1;  """)
-    assert results == expected
-
+    results = d.to_dataframe()
+    assert list(results.columns) == [
+        'seqname', 'source', 'feature', 'start', 'end', 'score', 'strand',
+        'frame', 'attributes']
+    assert results.loc[0, 'seqname'] == 'chr1'
+    assert results.loc[4, 'attributes'] == 'ID=rRNA1;'
 
     # get a gff file with too many fields...
     x = pybedtools.example_bedtool('c.gff')
@@ -1669,42 +1650,12 @@ def test_to_dataframe():
 
     names = ['seqname', 'source', 'feature', 'start', 'end', 'score', 'strand',
              'frame', 'attributes', 'count']
-    results = str(x.to_dataframe(names=names))
-    expected = fix_dataframe("""
-   seqname source feature  start   end score strand frame  \\
-0     chr1    ucb    gene    465   805     .      +     .   
-1     chr1    ucb    gene    631   899     .      +     .   
-2     chr1    ucb    mRNA    631   913     .      +     .   
-3     chr1    ucb     CDS    760   913     .      +     .   
-4     chr1    ucb     CDS    486   605     .      +     .   
-5     chr1    ucb     CDS    706  1095     .      +     .   
-6     chr1    ucb     CDS    174   326     .      +     .   
-7     chr1    ucb     CDS    439   630     .      +     .   
-8     chr1    ucb    mRNA    496   576     .      +     .   
-9     chr1    ucb    mRNA    486   605     .      +     .   
-10    chr1    ucb    mRNA    706   895     .      +     .   
-11    chr1    ucb    mRNA    174   326     .      +     .   
-12    chr1    ucb    mRNA    439   899     .      +     .   
-13    chr1    ucb    gene     60   269     .      -     .   
-
-                                           attributes  count  
-0   ID=thaliana_1_465_805;match=scaffold_801404.1;...     11  
-1         ID=AT1G01010;Name=AT1G01010;rname=AT1G01010      7  
-2   ID=AT1G01010.mRNA;Parent=AT1G01010;rname=AT1G0...      7  
-3               Parent=AT1G01010.mRNA;rname=AT1G01010      7  
-4               Parent=AT1G01010.mRNA;rname=AT1G01010      6  
-5               Parent=AT1G01010.mRNA;rname=AT1G01010      7  
-6               Parent=AT1G01010.mRNA;rname=AT1G01010      3  
-7               Parent=AT1G01010.mRNA;rname=AT1G01010      6  
-8   ID=AT1G01010.mRNA;Parent=AT1G01010;rname=AT1G0...      6  
-9   ID=AT1G01010.mRNA;Parent=AT1G01010;rname=AT1G0...      6  
-10  ID=AT1G01010.mRNA;Parent=AT1G01010;rname=AT1G0...      7  
-11  ID=AT1G01010.mRNA;Parent=AT1G01010;rname=AT1G0...      3  
-12  ID=AT1G01010.mRNA;Parent=AT1G01010;rname=AT1G0...     11  
-13  ID=thaliana_1_6160_6269;match=fgenesh1_pg.C_sc...      3  """)
-    assert results == expected
-
-
+    results = x.to_dataframe(names=names)
+    assert list(results.columns) == ['seqname', 'source', 'feature', 'start',
+                                     'end', 'score', 'strand', 'frame',
+                                     'attributes', 'count']
+    assert results.loc[0, 'seqname'] == 'chr1'
+    assert results.loc[13, 'count'] == 3
 
 
 def test_tail():

--- a/pybedtools/test/test_helpers.py
+++ b/pybedtools/test/test_helpers.py
@@ -63,12 +63,16 @@ def test_cleanup():
     assert os.path.exists(a.fn)
     assert os.path.exists(b.fn)
 
-def test_bedtools_check():
-    # this should run fine (especially since we've already imported pybedtools)
-    pybedtools.check_for_bedtools()
-
-    # but this should crap out
-    assert_raises(OSError, pybedtools.check_for_bedtools, **dict(program_to_check='nonexistent', force_check=True))
+# Test disabled, since we are no longer checking for pre-v2.15 versions by using
+# separate program calls
+#
+# TODO: remove this once v2.15 support is fully deprecated.
+#
+# def test_bedtools_check():
+#     # this should run fine (especially since we've already imported pybedtools)
+#     pybedtools.check_for_bedtools()
+#
+#     assert_raises(OSError, pybedtools.check_for_bedtools, **dict(program_to_check='nonexistent', force_check=True))
 
 def test_call():
     tmp = os.path.join(pybedtools.get_tempdir(), 'test.output')
@@ -120,7 +124,7 @@ def test_chromsizes():
         assert expected == results
 
         assert_raises(OSError,
-                      pybedtools.get_chromsizes_from_ucsc, 
+                      pybedtools.get_chromsizes_from_ucsc,
                       **dict(genome='hg17', mysql='nonexistent'))
 
         os.unlink('hg17.genome')

--- a/pybedtools/test/test_iter.py
+++ b/pybedtools/test/test_iter.py
@@ -11,7 +11,7 @@ import pybedtools
 #   http://code.google.com/p/python-nose/issues/detail?id=244#c1
 from functools import partial
 
-yamltestdesc = ['test_cases.yaml')]
+yamltestdesc = ['test_cases.yaml']
 
 if pybedtools.settings._v_2_27_plus:
     yamltestdesc.append('test_merge227.yaml'))

--- a/pybedtools/test/test_iter.py
+++ b/pybedtools/test/test_iter.py
@@ -12,7 +12,13 @@ import pybedtools
 from functools import partial
 
 this_dir = os.path.dirname(__file__)
-config_fn = os.path.join(this_dir, 'test_cases.yaml')
+yamltestdesc = [os.path.join(this_dir, 'test_cases.yaml')]
+if pybedtools.settings._v_2_27_plus:
+    yamltestdesc.append(os.path.join(this_dir, 'test_merge227.yaml'))
+    yamltestdesc.append(os.path.join(this_dir, 'test_shuffle227.yaml'))
+elif pybedtools.settings._v_2_15_plus and not pybedtools.settings._v_2_27_plus:
+    yamltestdesc.append(os.path.join(this_dir, 'test_merge215.yaml'))
+    yamltestdesc.append(os.path.join(this_dir, 'test_shuffle215.yaml'))
 
 def gz(x):
     """
@@ -117,6 +123,10 @@ def test_a_b_methods():
     Generator that yields tests, inserting different versions of `a` and `b` as
     needed
     """
+    for config_fn in yamltestdesc:
+        _test_a_b_methods(config_fn)
+
+def _test_a_b_methods(config_fn):
     for method, send_kwargs, expected in parse_yaml(config_fn):
         a_isbam = False
         b_isbam = False
@@ -167,6 +177,10 @@ def test_i_methods():
     """
     Generator that yields tests, inserting different versions of `i` as needed
     """
+    for config_fn in yamltestdesc:
+        _test_i_methods(config_fn)
+
+def _test_i_methods(config_fn):
     for method, send_kwargs, expected in parse_yaml(config_fn):
         i_isbam = False
         if 'ibam' in send_kwargs:
@@ -204,6 +218,10 @@ def test_bed_methods():
     """
     Generator that yields tests, inserting different versions of `bed` as needed
     """
+    for config_fn in yamltestdesc:
+        _test_bed_methods(config_fn)
+
+def _test_bed_methods(config_fn):
     for method, send_kwargs, expected in parse_yaml(config_fn):
         ignore = ['a', 'b','abam','i']
         skip_test = False

--- a/pybedtools/test/test_iter.py
+++ b/pybedtools/test/test_iter.py
@@ -14,12 +14,12 @@ from functools import partial
 yamltestdesc = ['test_cases.yaml']
 
 if pybedtools.settings._v_2_27_plus:
-    yamltestdesc.append('test_merge227.yaml'))
-    yamltestdesc.append('test_shuffle227.yaml'))
+    yamltestdesc.append('test_merge227.yaml')
+    yamltestdesc.append('test_shuffle227.yaml')
 
 elif pybedtools.settings._v_2_15_plus and not pybedtools.settings._v_2_27_plus:
-    yamltestdesc.append('test_merge215.yaml'))
-    yamltestdesc.append('test_shuffle215.yaml'))
+    yamltestdesc.append('test_merge215.yaml')
+    yamltestdesc.append('test_shuffle215.yaml')
 
 this_dir = os.path.dirname(__file__)
 yamltestdesc = [os.path.join(this_dir, i) for i in yamltestdesc]

--- a/pybedtools/test/test_iter.py
+++ b/pybedtools/test/test_iter.py
@@ -1,4 +1,4 @@
-from __future__ import print_function 
+from __future__ import print_function
 import difflib
 import itertools
 import yaml
@@ -11,14 +11,18 @@ import pybedtools
 #   http://code.google.com/p/python-nose/issues/detail?id=244#c1
 from functools import partial
 
-this_dir = os.path.dirname(__file__)
-yamltestdesc = [os.path.join(this_dir, 'test_cases.yaml')]
+yamltestdesc = ['test_cases.yaml')]
+
 if pybedtools.settings._v_2_27_plus:
-    yamltestdesc.append(os.path.join(this_dir, 'test_merge227.yaml'))
-    yamltestdesc.append(os.path.join(this_dir, 'test_shuffle227.yaml'))
+    yamltestdesc.append('test_merge227.yaml'))
+    yamltestdesc.append('test_shuffle227.yaml'))
+
 elif pybedtools.settings._v_2_15_plus and not pybedtools.settings._v_2_27_plus:
-    yamltestdesc.append(os.path.join(this_dir, 'test_merge215.yaml'))
-    yamltestdesc.append(os.path.join(this_dir, 'test_shuffle215.yaml'))
+    yamltestdesc.append('test_merge215.yaml'))
+    yamltestdesc.append('test_shuffle215.yaml'))
+
+this_dir = os.path.dirname(__file__)
+yamltestdesc = [os.path.join(this_dir, i) for i in yamltestdesc]
 
 def gz(x):
     """

--- a/pybedtools/test/test_merge215.yaml
+++ b/pybedtools/test/test_merge215.yaml
@@ -1,0 +1,27 @@
+# each test will be expanded into 6 tests, to check stream, file, and generator
+# versions of input and output BedTools
+
+
+#88888888888888888888888888888888888888888888888888888888888888888888888888888
+# merge - as functional up to 2.26
+#
+-   method: merge
+    kwargs:
+        i: a.bed
+        s: True
+        c: [4, 5, 6]
+        o: 'distinct'
+    expected: |
+        chr1	1	200	+	feature1,feature2	0	+
+        chr1	150	500	-	feature3	0	-
+        chr1	900	950	+	feature4	0	+
+
+-   method: merge
+    kwargs:
+        i: a.bed
+        s: True
+    expected: |
+        chr1	1	200	+
+        chr1	150	500	-
+        chr1	900	950	+
+

--- a/pybedtools/test/test_merge227.yaml
+++ b/pybedtools/test/test_merge227.yaml
@@ -1,0 +1,27 @@
+# each test will be expanded into 6 tests, to check stream, file, and generator
+# versions of input and output BedTools
+
+
+#88888888888888888888888888888888888888888888888888888888888888888888888888888
+# merge
+#
+
+-   method: merge
+    kwargs:
+        i: a.bed
+        s: True
+        c: [4, 5, 6]
+        o: 'distinct'
+    expected: |
+        chr1	1	200	feature1,feature2	0	+
+        chr1	150	500	feature3	0	-
+        chr1	900	950	feature4	0	+
+
+-   method: merge
+    kwargs:
+        i: a.bed
+        s: True
+    expected: |
+        chr1	1	200
+        chr1	150	500
+        chr1	900	950

--- a/pybedtools/test/test_shuffle215.yaml
+++ b/pybedtools/test/test_shuffle215.yaml
@@ -204,6 +204,26 @@
 
 -   method: merge
     kwargs:
+        i: a.bed
+        s: True
+    expected: |
+        chr1	1	200	+
+        chr1	150	500	-
+        chr1	900	950	+
+
+-   method: merge
+    kwargs:
+        i: a.bed
+        s: True
+        c: [4, 5, 6]
+        o: 'distinct'
+    expected: |
+        chr1	1	200	+	feature1,feature2	0	+
+        chr1	150	500	-	feature3	0	-
+        chr1	900	950	+	feature4	0	+
+
+-   method: merge
+    kwargs:
         i: b.bed
         d: 700
     expected: |
@@ -283,6 +303,23 @@
         chr1	5133830	5133932	Atp6v1h,uc007afn.1	1	+
         chr1	5140028	5140142	Atp6v1h,uc007afn.1	1	+
         chr1	5152185	5152630	Atp6v1h,uc007afn.1	1	+
+
+
+#88888888888888888888888888888888888888888888888888888888888888888888888888888
+# shuffle
+#
+#
+-   method: shuffle
+    kwargs:
+        i: a.bed
+        seed: 1
+        genome: hg19
+        chrom: True
+    expected: |
+        chr1	59535036	59535135	feature1	0	+
+        chr1	99179023	99179123	feature2	0	+
+        chr1	186189051	186189401	feature3	0	-
+        chr1	219133189	219133239	feature4	0	+
 
 #88888888888888888888888888888888888888888888888888888888888888888888888888888
 # annotate

--- a/pybedtools/test/test_shuffle227.yaml
+++ b/pybedtools/test/test_shuffle227.yaml
@@ -1,0 +1,21 @@
+# each test will be expanded into 6 tests, to check stream, file, and generator
+# versions of input and output BedTools
+
+# This file knows the correct output for version 2.27 of bedtools and later
+
+#88888888888888888888888888888888888888888888888888888888888888888888888888888
+# shuffle
+#
+#
+-   method: shuffle
+    kwargs:
+        i: a.bed
+        seed: 1
+        genome: hg19
+        chrom: True
+    expected: |
+        chr1    46341498        46341597        feature1        0       +
+        chr1    45615582        45615682        feature2        0       +
+        chr1    102762672       102763022       feature3        0       -
+        chr1    17293432        17293482        feature4        0       +
+


### PR DESCRIPTION
Hello,

As kindly stimulated in https://github.com/daler/pybedtools/pull/234 here I introduce a version detection of bedtools together with a version-specific test for shuffle. This seems to work nicely. I granted pybedtools.settings a new variable bedtools_version that is an array of numbers ([2.27.1] for me). And as proposed you have pybedtools.settings._v_2_27_plus. The latter is what the test routine now depends on - if that flag is set it does not test yaml files ending with _226.py and vice versa.

What is remaining is the problem with the extra column for merge. It would of course be trivial to just perform the analogous separation of the test for that. But this missing column made me nervous (see https://github.com/arq5x/bedtools2/issues/607) made me a bit nervous. Would it possibly be preferable to have extra -c and -o paramters to match the previous output instead of adjusting what is expected by default? Is there any way to predict the downstream consequences of that change for users of pybedtools?

Please direct me on the kind of version adjustment you expect. The different default format (!) in dependency of the bedtools for merge should possibly be mentioned somewhere.