### PR TITLE
pathlib integration

### DIFF
--- a/pybedtools/bedtool.py
+++ b/pybedtools/bedtool.py
@@ -446,6 +446,10 @@ class BedTool(object):
             fout.close()
 
         else:
+            # if fn is a Path object, we have to use its string representation
+            if 'pathlib.PurePath' in str(type(fn).__mro__):
+                fn = str(fn)
+
             # our work is already done
             if isinstance(fn, BedTool):
                 fn = fn.fn

--- a/pybedtools/test/test_pathlib.py
+++ b/pybedtools/test/test_pathlib.py
@@ -6,8 +6,6 @@ import six
 import pybedtools
 import pytest
 
-if six.PY2:
-    FileNotFoundError = IOError
 
 def test_pathlib_base():
     file = 'a.bed'
@@ -30,5 +28,6 @@ def test_pathlib_nonexistent_file():
     if six.PY2:
         with pytest.raises(ValueError):
             pybedtools.BedTool(path)
-    with pytest.raises(FileNotFoundError):
-        pybedtools.BedTool(path)
+    else:
+        with pytest.raises(FileNotFoundError):
+            pybedtools.BedTool(path)

--- a/pybedtools/test/test_pathlib.py
+++ b/pybedtools/test/test_pathlib.py
@@ -1,0 +1,32 @@
+import os
+import pathlib
+
+import six
+
+import pybedtools
+import pytest
+
+
+def test_pathlib_base():
+    file = 'a.bed'
+    fn = os.path.join(pybedtools.filenames.data_dir(), file)
+    path = pathlib.PurePath(fn)
+    assert pybedtools.BedTool(path).fn == fn
+
+
+def test_pathlib_derived():
+    file = 'a.bed'
+    fn = os.path.join(pybedtools.filenames.data_dir(), file)
+    path = pathlib.Path(fn)
+    assert pybedtools.BedTool(path).fn == fn
+
+
+# this may be unnecessary, as the check is performed after str conversion
+def test_pathlib_nonexistent_file():
+    fn = os.path.join(pybedtools.filenames.data_dir(), 'this_file_is_missing')
+    path = pathlib.Path(fn)
+    if six.PY2:
+        with pytest.raises(ValueError):
+            pybedtools.BedTool(path)
+    with pytest.raises(FileNotFoundError):
+        pybedtools.BedTool(path)

--- a/pybedtools/test/test_pathlib.py
+++ b/pybedtools/test/test_pathlib.py
@@ -6,6 +6,8 @@ import six
 import pybedtools
 import pytest
 
+if six.PY2:
+    FileNotFoundError = IOError
 
 def test_pathlib_base():
     file = 'a.bed'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 numpydoc
+pathlib
 psutil
 pytest
 pyyaml


### PR DESCRIPTION
When using pybedtools with [pathlib](https://pathlib.readthedocs.io/en/pep428/), the Path object has to be explicitly converted  to a string when constructing a BedTool.

>The string representation of a path is the raw filesystem path itself (in native form, e.g. with backslashes under Windows), which you can pass to any function taking a file path as a string

https://docs.python.org/3.4/library/pathlib.html#operators

I proprose to do this conversion internally to remove noise and to be more in line with the standard library. A notable example that can be used like this is `pandas.read_csv()` .

Old:
```
path = Path('a.bed')
pybedtools.BedTool(str(path))
```
New:
```
path = Path('a.bed')
pybedtools.BedTool(path)
```

*This is my first pull request ever... any hints and comments on how to do this right are very welcome :)* 
