### PR TITLE
Ignore bedtools warnings that are not capitalized

### DIFF
--- a/pybedtools/helpers.py
+++ b/pybedtools/helpers.py
@@ -454,7 +454,7 @@ def call_bedtools(
             # characters
             if isinstance(stderr, bytes):
                 stderr = stderr.decode("UTF_8")
-            if len(stderr) > 20 and "WARNING" in stderr[:20]:
+            if len(stderr) > 20 and "WARNING" in stderr[:20].upper():
                 sys.stderr.write(stderr)
             else:
                 raise BEDToolsError(subprocess.list2cmdline(cmds), stderr)


### PR DESCRIPTION
Bedtools does not have uniform way of logging warnings. This results
that some warning messag look like so:

    WARNING: Foo bar...

and others like so:

    Warning: Foo bar...

Pybedtools is currently ignoring warnings that start with "WARNING"
but not the ones that start with "Warning". This inconsistency causes
that some warnings are converted to errors which is undesired.