### PR TITLE
Make the build reproducible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -246,7 +246,7 @@ extensions = [
         depends=glob.glob('pybedtools/include/*h'),
         libraries=['stdc++', 'z'],
         include_dirs=['pybedtools/include/'],
-        sources=['pybedtools/cbedtools' + EXT] + glob.glob('pybedtools/include/*.cpp'),
+        sources=['pybedtools/cbedtools' + EXT] + sorted(glob.glob('pybedtools/include/*.cpp')),
         language='c++'),
 
     Extension(
@@ -254,7 +254,7 @@ extensions = [
         depends=glob.glob('pybedtools/include/*h'),
         libraries=['stdc++', 'z'],
         include_dirs=['pybedtools/include/'],
-        sources=['pybedtools/featurefuncs' + EXT] + glob.glob('pybedtools/include/*.cpp'),
+        sources=['pybedtools/featurefuncs' + EXT] + sorted(glob.glob('pybedtools/include/*.cpp')),
         language='c++'),
 ]
 


### PR DESCRIPTION
Whilst working on the [Reproducible Builds effort](https://reproducible-builds.org/) I noticed that pybedtools could not be built reproducibly. This is because it includes output inherited from non-deterministic filesystem ordering. I originally [filed this in Debian as bug #995259](https://bugs.debian.org/995259).