### PR TITLE
Update package classifiers stating Python support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -298,7 +298,7 @@ if __name__ == "__main__":
         setup_requires=[],
         install_requires=['six', 'pysam'],
         classifiers=[
-            'Development Status :: 4 - Beta',
+            'Development Status :: 5 - Production/Stable',
             'Intended Audience :: Science/Research',
             'License :: OSI Approved :: GNU General Public License (GPL)',
             'Topic :: Scientific/Engineering :: Bio-Informatics',


### PR DESCRIPTION
This package is tested against Python versions 3.6, 3.7, and 3.8:
https://github.com/daler/pybedtools/blob/f56c8514f8df2cd545b1f6ed923eab4a09e2ebeb/.github/workflows/main.yml#L8

Accordingly, `pybedtools` should state via its classifiers that these
versions are all supported!

Python 3.3 reached its EOL 4 years ago, on September 29, 2017.
https://www.python.org/dev/peps/pep-0398/#x-end-of-life

Other changes we could arguably make
------------------------------------
- Upgrade `Development Status` from `4 - Beta` to `5 - Production`
- Drop the 2.7 classifier (Python 2.7 was EOL in January, 2020)
  (given that Python 2.7 isn't part of the test suite, is it supported?)