### PR TITLE
Remove remnants of Python 2.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,7 @@ services:
 
 # Most of this is from http://conda.pydata.org/docs/travis.html
 install:
-    - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-        wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
-      else
-        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-      fi
+    - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"
     - hash -r

--- a/condatest.sh
+++ b/condatest.sh
@@ -72,14 +72,7 @@ if ! conda env list | grep -q $no_cy; then
         REQS=$TMPREQS
     fi
 
-    # genomepy>=0.8 not available for py27
-    TMPOPTREQS=$(tempfile)
-    grep -v genomepy optional-requirements.txt > $TMPOPTREQS
-    if [[ "$PY_VERSION" == "2.7" ]]; then
-        OPTREQS=$TMPOPTREQS
-    else
-        OPTREQS=optional-requirements.txt
-    fi
+    OPTREQS=optional-requirements.txt
 
     conda create -n $no_cy -y \
         --channel conda-forge \
@@ -115,8 +108,5 @@ pytest -v pybedtools/test/genomepy_integration.py
 log "copying over docs directory from repo"
 cp -r $TMP/docs .
 
-# numpydoc is not supported in py27, so we can't run doctests.
-if [[ "$PY_VERSION" != "2.7" ]]; then
-    log "sphinx doctests"
-    (cd docs && make clean doctest)
-fi
+log "sphinx doctests"
+(cd docs && make clean doctest)

--- a/docs/source/main.rst
+++ b/docs/source/main.rst
@@ -26,7 +26,7 @@ environments.
 
 Required
 ++++++++
-:Python_: version 2.7 or greater (Python 3 is supported). If you're setting up
+:Python_: version 3.6 or greater (Python 3 is supported). If you're setting up
           Python for the first time, the `Anaconda Python distribution
           <http://continuum.io/downloads>`_ is highly recommended.
 

--- a/pybedtools/__init__.py
+++ b/pybedtools/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import sys
 import subprocess

--- a/pybedtools/bedtool.py
+++ b/pybedtools/bedtool.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, division
 import tempfile
 from textwrap import dedent
 import shutil

--- a/pybedtools/contrib/long_range_interaction.py
+++ b/pybedtools/contrib/long_range_interaction.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import sys
 import itertools

--- a/pybedtools/contrib/venn_maker.py
+++ b/pybedtools/contrib/venn_maker.py
@@ -4,7 +4,6 @@ Interface between pybedtools and the R package VennDiagram.
 Rather than depend on the user to have rpy2 installed, this simply writes an
 R script that can be edited and tweaked by the user before being run in R.
 """
-from __future__ import print_function
 import os
 import string
 import pybedtools

--- a/pybedtools/helpers.py
+++ b/pybedtools/helpers.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import sys
 import os
 import gzip

--- a/pybedtools/scripts/examples/pbt_plotting_example.py
+++ b/pybedtools/scripts/examples/pbt_plotting_example.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
 import time
 import os
 import pybedtools

--- a/pybedtools/scripts/intron_exon_reads.py
+++ b/pybedtools/scripts/intron_exon_reads.py
@@ -7,7 +7,6 @@ multiple CPUs.
 Prints a tab-separated file containing class (exon, intron, both) and number of
 reads in each class.
 """
-from __future__ import print_function
 import pybedtools
 import argparse
 import os

--- a/pybedtools/test/test_1.py
+++ b/pybedtools/test/test_1.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import pybedtools
 import gzip
 import os, difflib, sys

--- a/pybedtools/test/test_gzip_support.py
+++ b/pybedtools/test/test_gzip_support.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 import os
 import tempfile
 import pybedtools.test.tfuncs as tfuncs

--- a/pybedtools/test/test_issues.py
+++ b/pybedtools/test/test_issues.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import pybedtools
 import gzip
 import os
@@ -469,13 +468,6 @@ def test_issue_196():
 
 
 def test_issue_178():
-    # Compatibility between py2/py3: py27 does not have FileNotFoundError, so
-    # set it to IOError (which does exist) for this function.
-    try:
-        FileNotFoundError
-    except NameError:
-        FileNotFoundError = IOError
-
     try:
         fn = pybedtools.example_filename("gdc.othersort.bam")
         pybedtools.contrib.bigwig.bam_to_bigwig(fn, genome="dm3", output="tmp.bw")

--- a/pybedtools/test/test_iter.py
+++ b/pybedtools/test/test_iter.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import difflib
 import copy
 import itertools


### PR DESCRIPTION
Python 2.7 reached its end of life in January of 2020. It's no longer
tested against, and commit 223c7e0b492fa1b693bad10d8e051caf2884795b
removed the classifiers which implies Python 2.7 support.

We should update documentation to state that Python 2.7 is no longer
supported, and update scripts to remove old workarounds for Python 2.7.
Finally, old `__future__` imports are meaningless on Python 3, and can
safely be deleted.