### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pybedtools/scripts/annotate.py
+++ b/pybedtools/scripts/annotate.py
@@ -120,7 +120,7 @@ def add_xstream(a, b, dist, updown, report_distance=False):
 
 def main():
     """
-    annotate a file with the neearest features in another.
+    annotate a file with the nearest features in another.
     """
     p = argparse.ArgumentParser(description=__doc__, prog=sys.argv[0])
     p.add_argument("-a", dest="a", help="file to annotate")

--- a/pybedtools/test/test_issues.py
+++ b/pybedtools/test/test_issues.py
@@ -560,7 +560,7 @@ def test_issue_217():
 
     assert x.name == "feature1"
 
-    # Previously the directly-created Interval object retuned None for a name.
+    # Previously the directly-created Interval object returned None for a name.
     assert y.name == "feature1"
 
     assert z.name == "feature1"


### PR DESCRIPTION
There are small typos in:
- pybedtools/scripts/annotate.py
- pybedtools/test/test_issues.py

Fixes:
- Should read `returned` rather than `retuned`.
- Should read `nearest` rather than `neearest`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md