### PR TITLE
fix #345 (and a better fix for #81 too)

### DIFF
--- a/pybedtools/helpers.py
+++ b/pybedtools/helpers.py
@@ -425,6 +425,7 @@ def call_bedtools(
                 "is filename (%s)",
                 tmpfn,
             )
+            cmds = list(map(str, cmds))
             logger.debug("helpers.call_bedtools(): cmds=%s", " ".join(cmds))
             outfile = open(tmpfn, "wb")
             p = subprocess.Popen(

--- a/pybedtools/test/test_issues.py
+++ b/pybedtools/test/test_issues.py
@@ -834,3 +834,14 @@ def test_issue_343():
         .remove_invalid()
         .sort()
     )
+
+
+def test_issue_345():
+    a = pybedtools.example_bedtool('a.bed')
+    b = pybedtools.example_bedtool('b.bed')
+    c = pybedtools.example_bedtool('c.gff')
+
+    z = a.intersect(b=[b.fn,c.fn], C=True, filenames=True)
+
+    # assert " ".join(z._cmds) == f'intersectBed -filenames -b {b.fn} {c.fn} -a {a.fn} -C'
+    assert " ".join(z._cmds) == f'intersectBed -a {a.fn} -filenames -b {b.fn} {c.fn} -C'


### PR DESCRIPTION
This PR introduces an `arg_order` argument, which supports controlling the order of arguments for bedtools programs that are sensitive to this (see #345 and #81).