### PR TITLE
Add minimal pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel", "Cython>=0.29.30,<3.0"]
+build-backend = "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
I'm using pybedtools within a [poetry](https://python-poetry.org/) controlled virtual environment, and without the addition of this minimal `pyproject.toml`, the build fails to find `Cython`. 

Adding this file allows the build to succeed, and makes pybedtools [PEP518](https://peps.python.org/pep-0518/) compliant, which should make builds smoother in the future.

I don't *think* this will impact any of your CI, but I'm not 100% sure.