### PR TITLE
fix(bedFile): remove register for ISO C++17

### DIFF
--- a/pybedtools/include/bedFile.h
+++ b/pybedtools/include/bedFile.h
@@ -89,7 +89,7 @@ BIN getBin(CHRPOS start, CHRPOS end) {
     start >>= _binFirstShift;
     end   >>= _binFirstShift;
     
-    for (register short i = 0; i < _binLevels; ++i) {
+    for (short i = 0; i < _binLevels; ++i) {
         if (start == end) return _binOffsetsExtended[i] + start;
         start >>= _binNextShift;
         end   >>= _binNextShift;


### PR DESCRIPTION
[C++17 removed the register keyword](https://en.wikipedia.org/wiki/C%2B%2B17#Removed_features).
This PR removes it from `bedFile.h` to avoid breaking package builds on C++17 and greater compliant compiler toolchains.