### PR TITLE
better detection of Path for Python 3.13

### DIFF
--- a/pybedtools/bedtool.py
+++ b/pybedtools/bedtool.py
@@ -13,6 +13,7 @@ import multiprocessing
 import gzip
 import pysam
 from warnings import warn
+import pathlib
 from pathlib import Path
 
 from .helpers import (
@@ -495,7 +496,7 @@ class BedTool(object):
 
         else:
             # if fn is a Path object, we have to use its string representation
-            if "pathlib.PurePath" in str(type(fn).__mro__):
+            if isinstance(fn, pathlib.PurePath):
                 fn = str(fn)
 
             # our work is already done


### PR DESCRIPTION
Seems like Python 3.13 might handle inheritance of `Path` objects differently as noted in #413; this PR tries to address that.

The original detection was using this from @caadr https://github.com/daler/pybedtools/commit/bbca348a190d972915af13ffefb24a5421590846, which at the time was an excellent way to handle the detection while maintaining backwards compatibility with Python <3.4 by not requiring `pathlib` to be imported.

Nowadays, with Python 3.5 end-of-life and no intention of supporting earlier versions, we can `import pathlib` with no problem, and it fixes Python 3.13 behavior as well.