### PR TITLE
improve pathlib handling (fix #421)

### DIFF
--- a/pybedtools/bedtool.py
+++ b/pybedtools/bedtool.py
@@ -1460,6 +1460,11 @@ class BedTool(object):
             "mapBed": ",",
         }
         stdin = None
+   
+        # If anything in kwargs is a pathlib Path, convert to string here.
+        for k, v in kwargs.items():
+            if isinstance(v, pathlib.PurePath):
+                kwargs[k] = str(v)
 
         # -----------------------------------------------------------------
         # Decide how to send instream1 to BEDTools.  If there's no implicit

--- a/pybedtools/test/test_pathlib.py
+++ b/pybedtools/test/test_pathlib.py
@@ -25,3 +25,16 @@ def test_pathlib_nonexistent_file():
     path = pathlib.Path(fn)
     with pytest.raises(FileNotFoundError):
         pybedtools.BedTool(path)
+
+
+def test_pathlib_on_methods():
+    # Above functions test the creation of BedTool from Path objects; here we
+    # test arbitrary methods to test that Path objs are converted to str when
+    # composing the relevant command.
+    fn_a = os.path.join(pybedtools.filenames.data_dir(), "a.bed")
+    fn_b = os.path.join(pybedtools.filenames.data_dir(), "b.bed")
+    p_a = pathlib.Path(fn_a)
+    p_b = pathlib.Path(fn_b)
+    bt = pybedtools.BedTool(fn_a)
+    res = bt.intersect(p_b)
+


### PR DESCRIPTION
Previously, `BedTool` creation supported `pathlib.Path` objects, but arbitrary `BedTool.*()` methods did not. This PR converts any Path objects to string when composing the command to pass to bedtools.

Addresses #421.