### PR TITLE
build: add wheels to pypi

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,9 @@ jobs:
         echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
         echo "WORKDIR=$(pwd)" >> $GITHUB_ENV
 
+    - name: install system deps
+      run: sudo apt-get install -y liblzma-dev
+
     - name: install miniforge
       run: |
         wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
@@ -182,7 +185,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
           CIBW_SKIP: "*-win*"
-          CIBW_BEFORE_BUILD: "pip install 'cython>3.0' && python setup.py cythonize"
+          CIBW_BEFORE_BUILD: "pip install 'cython>3.0' setuptools && python setup.py cythonize"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - 'v*'
   pull_request:
     types:
       - opened
@@ -13,7 +15,7 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -48,6 +50,12 @@ jobs:
         (cd dist && pip install pybedtools-*.tar.gz && cd $TMPDIR && python -c 'import pybedtools; print(pybedtools.__file__)')
         conda deactivate
 
+    - name: upload sdist
+      if: ${{ matrix.python-version == '3.12' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: sdist
+        path: dist/pybedtools-*.tar.gz
 
     - name: conda env and install locally
       # Set up conda and install pybedtools into that env
@@ -150,3 +158,56 @@ jobs:
         cd /tmp/docs
         git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY" gh-pages
         cd $WORKDIR
+
+
+  build-wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            cibw_archs: "x86_64"
+          - os: ubuntu-24.04-arm
+            cibw_archs: "aarch64"
+          - os: macos-latest
+            cibw_archs: "arm64 x86_64"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.21.3
+        env:
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
+          CIBW_SKIP: "*-win*"
+          CIBW_BEFORE_BUILD: "pip install 'cython>3.0' && python setup.py cythonize"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
+
+
+  publish:
+    needs: [build-and-test, build-wheels]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    environment: pypi
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: dist/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,9 +32,6 @@ jobs:
         echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
         echo "WORKDIR=$(pwd)" >> $GITHUB_ENV
 
-    - name: install system deps
-      run: sudo apt-get install -y liblzma-dev
-
     - name: install miniforge
       run: |
         wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
@@ -47,7 +44,7 @@ jobs:
       # with pip to make sure it works.
       run: |
         source "${HOME}/conda/etc/profile.d/conda.sh"
-        conda create -p ./cython-env -y "cython>3.0" python=${{ matrix.python-version }} gxx zlib setuptools --channel conda-forge
+        conda create -p ./cython-env -y "cython>3.0" python=${{ matrix.python-version }} gxx zlib setuptools xz --channel conda-forge
         conda activate ./cython-env
         python setup.py clean cythonize sdist
         (cd dist && pip install pybedtools-*.tar.gz && cd $TMPDIR && python -c 'import pybedtools; print(pybedtools.__file__)')


### PR DESCRIPTION
Closes #427.

- Adds a build-wheels job to CI that uses cibuildwheel to build binary wheels for:
  - manylinux and musllinux — x86_64 and aarch64 (native arm64 runner)
  - macos — arm64 and x86_64
  - Python 3.9–3.14 (also adds 3.14 to the existing build-and-test matrix)
- Adds a publish job that runs automatically on v* tags, after both build-and-test and build-wheels pass. It publishes the sdist and all wheels to PyPI using OIDC trusted publishing (no API token needed).
- PR development was AI assisted.

Before the first tagged release, one manual step is required on PyPI - add a Trusted Publisher for this repo.